### PR TITLE
Fix 139

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,11 +60,12 @@
         {
             "id": "blender-version",
             "type": "pickString",
-            "default": "4.2",
+            "default": "4.5",
             "options": [
                 "4.2",
                 "4.3",
-                "4.4"
+                "4.4",
+                "4.5"
             ],
             "description": "What blender version to launch"
         },

--- a/src/addons/meta_human_dna/dna_io/calibrator.py
+++ b/src/addons/meta_human_dna/dna_io/calibrator.py
@@ -192,8 +192,7 @@ class DNACalibrator(DNAExporter, DNAImporter):
                 ))
                 rotation_delta = Vector(bone_rotation) - dna_bone_rotation
                 # Only modify the bone rotations that are different to avoid floating point value drift
-                # TODO: Currently, we only calibrate facial bones we need to investigate why the local rotations of other bones are not matching
-                if bone_name.startswith('FACIAL_') and rotation_delta.length > 1e-3: # and not is_leaf:
+                if rotation_delta.length > 1e-3:
                     dna_x_rotations[dna_bone_index] = bone_rotation[0]
                     dna_y_rotations[dna_bone_index] = bone_rotation[1]
                     dna_z_rotations[dna_bone_index] = bone_rotation[2]

--- a/src/addons/meta_human_dna/dna_io/calibrator.py
+++ b/src/addons/meta_human_dna/dna_io/calibrator.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 class DNACalibrator(DNAExporter, DNAImporter):
 
     def calibrate_vertex_positions(self):
+        additional_meshes_by_lod = {}
         mesh_index_lookup = {self._dna_reader.getMeshName(index): index for index in range(self._dna_reader.getMeshCount())}
 
         for lod_index, mesh_objects in self._export_lods.items():
@@ -24,7 +25,16 @@ class DNACalibrator(DNAExporter, DNAImporter):
             for mesh_object, _ in mesh_objects:
                 real_name = mesh_object.name.replace(f'{self._instance.name}_', '')
                 logger.info(f'Calibrating "{real_name}" vertex positions...')
-                mesh_index = mesh_index_lookup[mesh_object.name.replace(f'{self._instance.name}_', '')]
+                mesh_index = mesh_index_lookup.get(real_name)
+                
+                # If the mesh index is not found, we assume that the mesh is not part of the DNA
+                # And we can add it to the additional meshes for this LOD
+                if mesh_index is None:
+                    additional_meshes_by_lod[lod_index] = additional_meshes_by_lod.get(lod_index, [])
+                    additional_meshes_by_lod[lod_index].append(mesh_object)
+                    logger.warning(f'Mesh "{real_name}" not found in DNA. This mesh will not be calibrated...')
+                    continue
+
                 bmesh_object = self.get_bmesh(mesh_object)
                 vertex_indices, vertex_positions = self.get_mesh_vertex_positions(bmesh_object)
                 bmesh_object.free()

--- a/src/addons/meta_human_dna/dna_io/calibrator.py
+++ b/src/addons/meta_human_dna/dna_io/calibrator.py
@@ -209,9 +209,10 @@ class DNACalibrator(DNAExporter, DNAImporter):
 
     def run(self) -> tuple[bool, str, str, Callable| None]:
         self.initialize_scene_data()
-        valid, title, message, fix = self.validate()
-        if not valid:
-            return False, title, message, fix
+        if self._instance.output_run_validations:
+            valid, title, message, fix = self.validate()
+            if not valid:
+                return False, title, message, fix
 
         if self._include_meshes:
             self.calibrate_vertex_positions()

--- a/src/addons/meta_human_dna/dna_io/exporter.py
+++ b/src/addons/meta_human_dna/dna_io/exporter.py
@@ -474,13 +474,10 @@ class DNAExporter:
         for index, bone_name in zip(indices, bone_names):
             self._dna_writer.setJointName(index=index, name=bone_name)
             self._bone_index_lookup[bone_name] = index
-
-            # TODO: Currently we only set the bone rotations for the facial bones.
-            # We need to investigate why the local rotations of other bones are not matching.
-            if bone_name.startswith('FACIAL_'):
-                dna_x_rotations[index] = rotations[index][0]
-                dna_y_rotations[index] = rotations[index][1]
-                dna_z_rotations[index] = rotations[index][2]
+            
+            dna_x_rotations[index] = rotations[index][0]
+            dna_y_rotations[index] = rotations[index][1]
+            dna_z_rotations[index] = rotations[index][2]
         
         self._dna_writer.setJointHierarchy(hierarchy)
         self._dna_writer.setNeutralJointTranslations(translations)

--- a/src/addons/meta_human_dna/dna_io/exporter.py
+++ b/src/addons/meta_human_dna/dna_io/exporter.py
@@ -185,7 +185,7 @@ class DNAExporter:
             meshes_with_mismatched_origins = []
             for _, mesh_objects in self._export_lods.items():
                 for mesh_object, _ in mesh_objects:
-                    if (self._rig_object.location.copy() - mesh_object.location).length > 1e-5:
+                    if (self._rig_object.location.copy() - mesh_object.location).length > 1e-4:
                         meshes_with_mismatched_origins.append(mesh_object)
             
             if meshes_with_mismatched_origins:
@@ -501,7 +501,10 @@ class DNAExporter:
             try:
                 image.save(filepath=str(new_image_path))
             except Exception:
-                image.save_render(filepath=str(new_image_path))
+                try:
+                    image.save_render(filepath=str(new_image_path))
+                except Exception as error:
+                    logger.error(f"Failed to export image {image.name}: {error}")
             logger.info(f"Image {image.name} exported successfully to: {new_image_path}")
 
     def save_vertex_colors(self):
@@ -513,9 +516,10 @@ class DNAExporter:
 
     def run(self) -> tuple[bool, str, str, Callable| None]:
         self.initialize_scene_data()
-        valid, title, message, fix = self.validate()
-        if not valid:
-            return False, title, message, fix
+        if self._instance.output_run_validations:
+            valid, title, message, fix = self.validate()
+            if not valid:
+                return False, title, message, fix
 
         # Clear the mesh data
         self._dna_writer.clearMeshNames()

--- a/src/addons/meta_human_dna/operators.py
+++ b/src/addons/meta_human_dna/operators.py
@@ -786,7 +786,7 @@ class SendToMetaHumanCreator(bpy.types.Operator):
                         title=title,
                         message=message,
                         fix=fix,
-                        width=300
+                        width=500
                     )
                     return {'CANCELLED'}
                 else:

--- a/src/addons/meta_human_dna/release_notes.md
+++ b/src/addons/meta_human_dna/release_notes.md
@@ -1,16 +1,9 @@
-## Major Changes
-* Removed Send to Unreal functionality and refactored for Send to MetaHuman Creator. This can now be done entirely through DNA files now. (This will be more streamlined with RPC functionality in future releases)
-* MetaHuman Creator - body support [#120](https://github.com/poly-hammer/meta-human-dna-addon/issues/120)
-
 ## Minor Changes
-* Shape keys now calibrate to DNA instead of old Send to Unreal SkeletalMesh workflow
-* Basis Shape key operator for quickly modifying the basis shape
-* DNA exporter, now use the "component" (i.e. 'head.dna', 'body.dna') name for the file instead of the instance name
+* Added validate option to output panel. By default the validations are run before export, but this option allows the user to turn them off.
 
 ## Patch Changes
-* Fixed Normal UV Map name on import [#126](https://github.com/poly-hammer/meta-human-dna-addon/issues/126)
-* Fixed LOD import bug [#131](https://github.com/poly-hammer/meta-human-dna-addon/issues/131)
-* Head frequently gets messed up on undo [#122](https://github.com/poly-hammer/meta-human-dna-addon/issues/122)
+* Fixed Edit bone rotations on the body are not calibrating[#139](https://github.com/poly-hammer/meta-human-dna-addon/issues/139)
+* Fixed Mesh origin validation [#140](https://github.com/poly-hammer/meta-human-dna-addon/issues/140)
 
 
 > [!WARNING]  
@@ -18,7 +11,7 @@
 
 ## Tests Passing On
 * Metahuman Creator Version `6.0.0`
-* Blender `4.2`, `4.3` (installed from blender.org)
+* Blender `4.5` (installed from blender.org)
 * Unreal `5.6`
 > [!NOTE]  
 > Due to all the changes in Unreal 5.6, MetaHumans v6, and the addon still being in Beta, there is no backward support for earlier versions. Please use an older addon release if needed.

--- a/src/addons/meta_human_dna/rig_logic.py
+++ b/src/addons/meta_human_dna/rig_logic.py
@@ -346,6 +346,11 @@ class RigLogicInstance(bpy.types.PropertyGroup):
     ) # type: ignore
 
     # ----- Output Properties -----
+    output_run_validations: bpy.props.BoolProperty(
+        name="Validate",
+        description="Whether to run validations before exporting",
+        default=True
+    ) # type: ignore
     output_folder_path: bpy.props.StringProperty(
         name="Output Folder",
         description="The root folder where the output files will be saved",

--- a/src/addons/meta_human_dna/ui/view_3d.py
+++ b/src/addons/meta_human_dna/ui/view_3d.py
@@ -786,6 +786,8 @@ class META_HUMAN_DNA_PT_buttons_sub_panel(bpy.types.Panel):
             row = self.layout.row()
             active_index = properties.rig_logic_instance_list_active_index
             instance = properties.rig_logic_instance_list[active_index]
+            row.prop(instance, 'output_run_validations')
+            row = self.layout.row()
             if not instance.output_folder_path:
                 row.enabled = False
             row.scale_y = 2.0


### PR DESCRIPTION
# Minor Changes
* Added validate option to output panel. By default the validations are run before export, but this option allows the user to turn them off.

# Path Changes
* Fixed Edit bone rotations on the body are not calibrating[#139](https://github.com/poly-hammer/meta-human-dna-addon/issues/139)
* Fixed Mesh origin validation [#140](https://github.com/poly-hammer/meta-human-dna-addon/issues/140)